### PR TITLE
Gerunner fix disable ge cache 

### DIFF
--- a/dicp/dicp/vendor/AscendGraph/codegen/ge_init_config.json
+++ b/dicp/dicp/vendor/AscendGraph/codegen/ge_init_config.json
@@ -1,6 +1,5 @@
 {
     "ge.graphRunMode": "0",
     "ge.exec.precision_mode": "allow_fp32_to_fp16",
-    "ge.graph_compiler_cache_dir": "/tmp/dicp_ascend",
     "ge.op_compiler_cache_mode": "disable"
 }


### PR DESCRIPTION
if we open cache, it will be error if we run a second time when there are cache